### PR TITLE
add options-based preflight to CheckFlag

### DIFF
--- a/company_test.go
+++ b/company_test.go
@@ -1,6 +1,7 @@
 package rulesengine_test
 
 import (
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -64,7 +65,7 @@ func TestCompanyAddMetric(t *testing.T) {
 				defer wg.Done()
 
 				// Create a metric with a unique event subtype to avoid collision
-				uniqueSubtype := "test-event-" + time.Now().String() + "-" + string(rune(index))
+				uniqueSubtype := "test-event-" + time.Now().String() + "-" + strconv.Itoa(index)
 				metric := createTestMetric(company, uniqueSubtype, rulesengine.MetricPeriodAllTime, int64(index))
 
 				// Add the metric

--- a/errors.go
+++ b/errors.go
@@ -26,3 +26,5 @@ func newRulesEngineError(err string, status int) error {
 
 var ErrorUnexpected = newRulesEngineError("unexpected error", http.StatusInternalServerError)
 var ErrorFlagNotFound = newRulesEngineError("flag not found", http.StatusNotFound)
+var ErrorNegativePreflightUsage = newRulesEngineError("preflight usage cannot be negative", http.StatusBadRequest)
+var ErrorNegativePreflightCreditCost = newRulesEngineError("preflight credit cost cannot be negative", http.StatusBadRequest)

--- a/flagcheck.go
+++ b/flagcheck.go
@@ -113,8 +113,19 @@ func CheckFlag(
 	company *Company,
 	user *User,
 	flag *Flag,
+	opts ...CheckFlagOption,
 ) (*CheckFlagResult, error) {
+	options := newCheckFlagOptions()
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	resp := &CheckFlagResult{Reason: ReasonNoRulesMatched}
+
+	if err := options.validate(); err != nil {
+		resp.Err = err
+		return resp, err
+	}
 
 	if flag == nil {
 		resp.Reason = ReasonFlagNotFound
@@ -164,9 +175,12 @@ func CheckFlag(
 			}
 
 			checkRuleResp, err := ruleChecker.Check(ctx, &CheckScope{
-				Company: company,
-				Rule:    rule,
-				User:    user,
+				Company:    company,
+				Rule:       rule,
+				User:       user,
+				creditCost: options.creditCost,
+				usage:      options.usage,
+				eventUsage: options.eventUsage,
 			})
 			if err != nil {
 				resp.Err = err

--- a/flagcheck_test.go
+++ b/flagcheck_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/schematichq/rulesengine"
+	"github.com/schematichq/rulesengine/null"
 	"github.com/schematichq/rulesengine/typeconvert"
 	"github.com/stretchr/testify/assert"
 )
@@ -875,6 +876,306 @@ func TestCheckFlag(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, flag.DefaultValue, result.Value)
 			assert.Equal(t, rulesengine.ReasonNoRulesMatched, result.Reason)
+		})
+	})
+
+	t.Run("Preflight options", func(t *testing.T) {
+		// Builds a flag wrapping a credit-balance rule with an optional event_subtype.
+		// Returns flag and rule so callers can assert on result.RuleID == &rule.ID.
+		creditFlag := func(creditID string, consumptionRate float64, eventSubtype *string) (*rulesengine.Flag, *rulesengine.Rule) {
+			rule := createTestRule()
+			condition := createTestCondition(rulesengine.ConditionTypeCredit)
+			condition.Operator = typeconvert.ComparableOperatorGte
+			condition.CreditID = &creditID
+			condition.ConsumptionRate = null.Nullable(consumptionRate)
+			condition.EventSubtype = eventSubtype
+			rule.Conditions = []*rulesengine.Condition{condition}
+
+			flag := createTestFlag()
+			flag.DefaultValue = false
+			flag.Rules = []*rulesengine.Rule{rule}
+			return flag, rule
+		}
+
+		t.Run("Validation", func(t *testing.T) {
+			t.Run("Rejects negative WithUsage", func(t *testing.T) {
+				company := createTestCompany()
+				flag := createTestFlag()
+
+				result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithUsage(-1))
+
+				assert.Equal(t, rulesengine.ErrorNegativePreflightUsage, err)
+				assert.Equal(t, rulesengine.ErrorNegativePreflightUsage, result.Err)
+			})
+
+			t.Run("Rejects negative WithEventUsage", func(t *testing.T) {
+				company := createTestCompany()
+				flag := createTestFlag()
+
+				result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithEventUsage("api-calls", -5))
+
+				assert.Equal(t, rulesengine.ErrorNegativePreflightUsage, err)
+				assert.Equal(t, rulesengine.ErrorNegativePreflightUsage, result.Err)
+			})
+
+			t.Run("Rejects negative WithCreditCost", func(t *testing.T) {
+				company := createTestCompany()
+				flag := createTestFlag()
+
+				result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithCreditCost("credit-abc", -0.5))
+
+				assert.Equal(t, rulesengine.ErrorNegativePreflightCreditCost, err)
+				assert.Equal(t, rulesengine.ErrorNegativePreflightCreditCost, result.Err)
+			})
+
+			t.Run("Accepts zero values", func(t *testing.T) {
+				company := createTestCompany()
+				flag := createTestFlag()
+
+				result, err := rulesengine.CheckFlag(
+					ctx, company, nil, flag,
+					rulesengine.WithUsage(0),
+					rulesengine.WithEventUsage("api-calls", 0),
+					rulesengine.WithCreditCost("credit-abc", 0),
+				)
+
+				assert.NoError(t, err)
+				assert.Nil(t, result.Err)
+			})
+		})
+
+		t.Run("WithCreditCost gates credit balance directly", func(t *testing.T) {
+			// Balance 100, rate 1 (would pass alone), credit_cost 50 → 100 >= 50 → true
+			company := createTestCompany()
+			creditID := "credit-abc"
+			company.CreditBalances = map[string]float64{creditID: 100.0}
+
+			flag, rule := creditFlag(creditID, 1.0, nil)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithCreditCost(creditID, 50.0))
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID)
+		})
+
+		t.Run("WithCreditCost fails when balance < cost", func(t *testing.T) {
+			// Balance 10, consumption_rate 1 (would pass), cost 50 → 10 < 50 → false
+			company := createTestCompany()
+			creditID := "credit-abc"
+			company.CreditBalances = map[string]float64{creditID: 10.0}
+
+			flag, _ := creditFlag(creditID, 1.0, nil)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithCreditCost(creditID, 50.0))
+
+			assert.NoError(t, err)
+			assert.Nil(t, result.RuleID)
+		})
+
+		t.Run("WithCreditCost ignores unrelated credit_id keys", func(t *testing.T) {
+			// credit_cost has a different credit_id → engine falls through to rate.
+			company := createTestCompany()
+			creditID := "credit-abc"
+			company.CreditBalances = map[string]float64{creditID: 5.0}
+
+			flag, rule := creditFlag(creditID, 1.0, nil)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithCreditCost("credit-other", 9999))
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID)
+		})
+
+		t.Run("WithUsage multiplies by consumption_rate on credit balance", func(t *testing.T) {
+			// usage 50, rate 0.0001 → 0.005 credits needed, balance 1.0 → true
+			company := createTestCompany()
+			creditID := "credit-abc"
+			company.CreditBalances = map[string]float64{creditID: 1.0}
+
+			flag, rule := creditFlag(creditID, 0.0001, nil)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithUsage(50))
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID)
+		})
+
+		t.Run("WithUsage fails credit balance when product exceeds balance", func(t *testing.T) {
+			// usage 20_000, rate 0.0001 → 2 credits needed, balance 1.0 → false
+			company := createTestCompany()
+			creditID := "credit-abc"
+			company.CreditBalances = map[string]float64{creditID: 1.0}
+
+			flag, _ := creditFlag(creditID, 0.0001, nil)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithUsage(20_000))
+
+			assert.NoError(t, err)
+			assert.Nil(t, result.RuleID)
+		})
+
+		t.Run("WithEventUsage with matching subtype on credit balance", func(t *testing.T) {
+			// quantity 100, rate 0.05 → 5 credits needed, balance 10 → true
+			company := createTestCompany()
+			creditID := "credit-abc"
+			eventSubtype := "api-calls"
+			company.CreditBalances = map[string]float64{creditID: 10.0}
+
+			flag, rule := creditFlag(creditID, 0.05, &eventSubtype)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithEventUsage(eventSubtype, 100))
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID)
+		})
+
+		t.Run("WithEventUsage with non-matching subtype falls through", func(t *testing.T) {
+			// event_usage is keyed to "other-events" but condition is "api-calls".
+			// Falls through to balance >= consumption_rate: 5 >= 1 → true.
+			company := createTestCompany()
+			creditID := "credit-abc"
+			eventSubtype := "api-calls"
+			company.CreditBalances = map[string]float64{creditID: 5.0}
+
+			flag, rule := creditFlag(creditID, 1.0, &eventSubtype)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithEventUsage("other-events", 9999))
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID)
+		})
+
+		t.Run("WithEventUsage preferred over WithUsage on credit balance", func(t *testing.T) {
+			// event_usage matches subtype → 5 × 1 = 5 needed, balance 10 → true.
+			// usage 1M × 1 = 1M would fail. event_usage must win.
+			company := createTestCompany()
+			creditID := "credit-abc"
+			eventSubtype := "api-calls"
+			company.CreditBalances = map[string]float64{creditID: 10.0}
+
+			flag, rule := creditFlag(creditID, 1.0, &eventSubtype)
+
+			result, err := rulesengine.CheckFlag(
+				ctx, company, nil, flag,
+				rulesengine.WithUsage(1_000_000),
+				rulesengine.WithEventUsage(eventSubtype, 5),
+			)
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID, "event_usage match should win over generic usage on credit balance")
+		})
+
+		t.Run("WithCreditCost takes precedence over WithUsage", func(t *testing.T) {
+			// credit_cost says 5 (passes); usage 1M × 0.05 = 50K (would fail).
+			// credit_cost should short-circuit and pass.
+			company := createTestCompany()
+			creditID := "credit-abc"
+			company.CreditBalances = map[string]float64{creditID: 10.0}
+
+			flag, rule := creditFlag(creditID, 0.05, nil)
+
+			result, err := rulesengine.CheckFlag(
+				ctx, company, nil, flag,
+				rulesengine.WithCreditCost(creditID, 5.0),
+				rulesengine.WithUsage(1_000_000),
+			)
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID)
+		})
+
+		t.Run("WithCreditCost takes precedence over WithEventUsage", func(t *testing.T) {
+			// credit_cost says 5 (passes); event_usage 1M × 0.05 = 50K (would fail).
+			// credit_cost should short-circuit and pass.
+			company := createTestCompany()
+			creditID := "credit-abc"
+			eventSubtype := "api-calls"
+			company.CreditBalances = map[string]float64{creditID: 10.0}
+
+			flag, rule := creditFlag(creditID, 0.05, &eventSubtype)
+
+			result, err := rulesengine.CheckFlag(
+				ctx, company, nil, flag,
+				rulesengine.WithCreditCost(creditID, 5.0),
+				rulesengine.WithEventUsage(eventSubtype, 1_000_000),
+			)
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID, "credit_cost should short-circuit event_usage")
+		})
+
+		t.Run("WithUsage flips metric condition to false", func(t *testing.T) {
+			// metric value 5, limit 10 → 5 <= 10 → true. With usage=10 → 15 > 10 → false.
+			company := createTestCompany()
+
+			rule := createTestRule()
+			condition := createTestCondition(rulesengine.ConditionTypeMetric)
+			condition.Operator = typeconvert.ComparableOperatorLte
+			limit := int64(10)
+			condition.MetricValue = &limit
+			rule.Conditions = []*rulesengine.Condition{condition}
+
+			metric := createTestMetric(company, *condition.EventSubtype, *condition.MetricPeriod, 5)
+			company.Metrics = append(company.Metrics, metric)
+
+			flag := createTestFlag()
+			flag.DefaultValue = false
+			flag.Rules = []*rulesengine.Rule{rule}
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithUsage(10))
+
+			assert.NoError(t, err)
+			assert.Nil(t, result.RuleID, "usage should push metric over the limit")
+		})
+
+		t.Run("WithEventUsage preferred over WithUsage on metric", func(t *testing.T) {
+			// event_usage matches subtype → uses 10 (push over). usage 1 ignored.
+			company := createTestCompany()
+
+			rule := createTestRule()
+			condition := createTestCondition(rulesengine.ConditionTypeMetric)
+			condition.Operator = typeconvert.ComparableOperatorLte
+			limit := int64(10)
+			condition.MetricValue = &limit
+			rule.Conditions = []*rulesengine.Condition{condition}
+
+			metric := createTestMetric(company, *condition.EventSubtype, *condition.MetricPeriod, 5)
+			company.Metrics = append(company.Metrics, metric)
+
+			flag := createTestFlag()
+			flag.DefaultValue = false
+			flag.Rules = []*rulesengine.Rule{rule}
+
+			result, err := rulesengine.CheckFlag(
+				ctx, company, nil, flag,
+				rulesengine.WithUsage(1),
+				rulesengine.WithEventUsage(*condition.EventSubtype, 10),
+			)
+
+			assert.NoError(t, err)
+			assert.Nil(t, result.RuleID, "event_usage match should win over usage")
+		})
+
+		t.Run("WithUsage flips int trait condition to false", func(t *testing.T) {
+			// trait 5, limit 10 → 5 <= 10 → true. With usage=10 → 15 > 10 → false.
+			company := createTestCompany()
+
+			rule := createTestRule()
+			condition := createTestCondition(rulesengine.ConditionTypeTrait)
+			condition.Operator = typeconvert.ComparableOperatorLte
+			condition.TraitValue = "10"
+			rule.Conditions = []*rulesengine.Condition{condition}
+
+			company.Traits = append(company.Traits, createTestTrait("5", condition.TraitDefinition))
+
+			flag := createTestFlag()
+			flag.DefaultValue = false
+			flag.Rules = []*rulesengine.Rule{rule}
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag, rulesengine.WithUsage(10))
+
+			assert.NoError(t, err)
+			assert.Nil(t, result.RuleID, "usage should push int trait over limit")
 		})
 	})
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,127 @@
+package rulesengine
+
+// CheckFlagOption configures a CheckFlag invocation. Functional options let
+// callers express preflight semantics ("simulate this much additional usage"
+// or "this is the exact credit cost") without expanding the positional
+// signature of CheckFlag.
+//
+// Zero quantities passed to WithUsage or WithEventUsage are treated as no-ops
+// on the condition types where they would apply, and the engine falls through
+// to the next precedence tier. Negative values are rejected by CheckFlag with
+// ErrorNegativePreflightUsage / ErrorNegativePreflightCreditCost — they
+// indicate a caller-side bug rather than a meaningful preflight intent.
+//
+// Preflight options influence whether a rule matches, but they do not
+// rewrite the usage figures reported back on the result. CheckFlagResult's
+// FeatureUsage still reflects the company's current (un-simulated) value —
+// callers know their own pending quantity and can add it if they need a
+// post-preflight projection.
+type CheckFlagOption func(*checkFlagOptions)
+
+// checkFlagOptions is the resolved bag of optional inputs threaded through to
+// each condition check. Empty/zero values == legacy behavior (the engine
+// evaluates each condition using only the condition's own configuration).
+//
+// Callers can provide multiple options; the engine picks the most specific
+// one for each condition it evaluates. For credit-balance conditions:
+// CreditCost (keyed by credit_id) wins over EventUsage (keyed by
+// event_subtype) wins over Usage (generic). For metric conditions:
+// EventUsage wins over Usage when the subtype matches. Trait conditions
+// only ever use Usage.
+type checkFlagOptions struct {
+	// creditCost is keyed by billing_credit_id → a per-call cost in credits
+	// the caller has already computed. When a credit-balance condition
+	// matches one of these keys, the engine gates on `balance >= cost`
+	// directly, with no quantity or consumption_rate math.
+	creditCost map[string]float64
+
+	// usage is a generic simulated quantity applied to whatever numeric
+	// condition is being evaluated. For metric and trait-int conditions,
+	// the quantity is added to the current value. For credit-balance
+	// conditions, the credit cost compared against the balance is
+	// `quantity × consumption_rate`. Use when the caller doesn't need to
+	// disambiguate across event subtypes.
+	usage *int64
+
+	// eventUsage is keyed by event_subtype → simulated quantity. Lets the
+	// caller target a specific subtype when several may be in flight.
+	// Applied to metric conditions whose event_subtype matches (quantity is
+	// added to the current metric value) and to credit-balance conditions
+	// whose event_subtype matches (compared as `quantity × consumption_rate`
+	// against the balance).
+	eventUsage map[string]int64
+}
+
+// newCheckFlagOptions returns a zero-valued checkFlagOptions with its maps
+// initialized, so option setters don't need to nil-check before writing.
+func newCheckFlagOptions() *checkFlagOptions {
+	return &checkFlagOptions{
+		creditCost: make(map[string]float64),
+		eventUsage: make(map[string]int64),
+	}
+}
+
+// validate rejects negative preflight values at the CheckFlag boundary. Zero
+// remains a valid no-op for usage/event_usage and the "this call is free"
+// semantic for credit_cost; negatives are programming errors and surfaced as
+// such so callers can fix the source bug instead of silently misbehaving.
+func (o *checkFlagOptions) validate() error {
+	if o.usage != nil && *o.usage < 0 {
+		return ErrorNegativePreflightUsage
+	}
+	for _, q := range o.eventUsage {
+		if q < 0 {
+			return ErrorNegativePreflightUsage
+		}
+	}
+	for _, c := range o.creditCost {
+		if c < 0 {
+			return ErrorNegativePreflightCreditCost
+		}
+	}
+	return nil
+}
+
+// WithCreditCost gates a credit-balance condition on `balance >= cost` when
+// the condition's credit_id matches. Lets callers supply an already-
+// computed per-call cost in credits, bypassing the engine's default
+// quantity × consumption_rate math. Highest precedence on credit-balance
+// conditions when supplied. Call multiple times to attach costs for
+// several credit types in the same check.
+//
+// Unlike WithUsage / WithEventUsage, a zero cost is not treated as a no-op:
+// cost is gated as-is, so `WithCreditCost(id, 0)` passes whenever the balance
+// is non-negative (the "this call is free" semantic). Callers who want to
+// skip the override should omit the option entirely. Negative costs are
+// rejected by CheckFlag with ErrorNegativePreflightCreditCost.
+func WithCreditCost(creditID string, cost float64) CheckFlagOption {
+	return func(o *checkFlagOptions) {
+		o.creditCost[creditID] = cost
+	}
+}
+
+// WithUsage simulates additional usage of a generic quantity for any numeric
+// condition encountered while evaluating rules. For metric conditions, the
+// quantity is added to the current metric value. For trait conditions with
+// an int-comparable trait, it's added to the trait value. For credit-balance
+// conditions, the credit cost compared against the balance is
+// `quantity × consumption_rate`. Zero is a no-op; negative quantities are
+// rejected by CheckFlag with ErrorNegativePreflightUsage.
+func WithUsage(quantity int64) CheckFlagOption {
+	return func(o *checkFlagOptions) {
+		o.usage = &quantity
+	}
+}
+
+// WithEventUsage simulates additional usage of a specific event_subtype.
+// Applied to metric conditions whose event_subtype matches (quantity is
+// added to the current metric value) and to credit-balance conditions whose
+// event_subtype matches (compared as `quantity × consumption_rate` against
+// the balance). Preferred over WithUsage on those conditions when the
+// caller knows the specific subtype. Zero is a no-op; negative quantities
+// are rejected by CheckFlag with ErrorNegativePreflightUsage.
+func WithEventUsage(eventSubtype string, quantity int64) CheckFlagOption {
+	return func(o *checkFlagOptions) {
+		o.eventUsage[eventSubtype] = quantity
+	}
+}

--- a/rulecheck.go
+++ b/rulecheck.go
@@ -12,6 +12,14 @@ type CheckScope struct {
 	Company *Company
 	Rule    *Rule
 	User    *User
+
+	// Preflight options, populated by CheckFlag from CheckFlagOption setters.
+	// Unexported so external callers of RuleCheckService.Check can't bypass
+	// the validation that CheckFlag runs on these values. Empty/nil == legacy
+	// behavior on every condition check.
+	creditCost map[string]float64
+	usage      *int64
+	eventUsage map[string]int64
 }
 
 type CheckResult struct {
@@ -42,14 +50,14 @@ func (s *RuleCheckService) Check(ctx context.Context, scope *CheckScope) (res *C
 
 	var match bool
 	for _, condition := range scope.Rule.Conditions {
-		match, err = s.checkCondition(ctx, scope.Company, scope.User, condition)
+		match, err = s.checkCondition(ctx, scope, condition)
 		if err != nil || !match {
 			return
 		}
 	}
 
 	for _, group := range scope.Rule.ConditionGroups {
-		match, err = s.checkConditionGroup(ctx, scope.Company, scope.User, group)
+		match, err = s.checkConditionGroup(ctx, scope, group)
 		if err != nil || !match {
 			return
 		}
@@ -59,43 +67,43 @@ func (s *RuleCheckService) Check(ctx context.Context, scope *CheckScope) (res *C
 	return
 }
 
-func (s *RuleCheckService) checkCondition(ctx context.Context, company *Company, user *User, condition *Condition) (match bool, err error) {
+func (s *RuleCheckService) checkCondition(ctx context.Context, scope *CheckScope, condition *Condition) (match bool, err error) {
 	if condition == nil {
 		return false, nil
 	}
 
 	switch condition.ConditionType {
 	case ConditionTypeCompany:
-		return s.checkCompanyCondition(ctx, company, condition)
+		return s.checkCompanyCondition(ctx, scope.Company, condition)
 	case ConditionTypeMetric:
-		return s.checkMetricCondition(ctx, company, condition)
+		return s.checkMetricCondition(ctx, scope, condition)
 	case ConditionTypeBasePlan:
-		return s.checkBasePlanCondition(ctx, company, condition)
+		return s.checkBasePlanCondition(ctx, scope.Company, condition)
 	case ConditionTypePlan:
-		return s.checkPlanCondition(ctx, company, condition)
+		return s.checkPlanCondition(ctx, scope.Company, condition)
 	case ConditionTypePlanVersion:
-		return s.checkPlanVersionCondition(ctx, company, condition)
+		return s.checkPlanVersionCondition(ctx, scope.Company, condition)
 	case ConditionTypeTrait:
-		return s.checkTraitCondition(ctx, company, user, condition)
+		return s.checkTraitCondition(ctx, scope, condition)
 	case ConditionTypeUser:
-		return s.checkUserCondition(ctx, user, condition)
+		return s.checkUserCondition(ctx, scope.User, condition)
 	case ConditionTypeBillingProduct:
-		return s.checkBillingProductCondition(ctx, company, condition)
+		return s.checkBillingProductCondition(ctx, scope.Company, condition)
 	case ConditionTypeCredit:
-		return s.checkCreditBalanceCondition(ctx, company, condition)
+		return s.checkCreditBalanceCondition(ctx, scope, condition)
 	}
 
 	return
 }
 
-func (s *RuleCheckService) checkConditionGroup(ctx context.Context, company *Company, user *User, group *ConditionGroup) (bool, error) {
+func (s *RuleCheckService) checkConditionGroup(ctx context.Context, scope *CheckScope, group *ConditionGroup) (bool, error) {
 	if group == nil {
 		return false, nil
 	}
 
 	// Condition groups are OR'd together, so we return true if any condition matches
 	for _, condition := range group.Conditions {
-		match, err := s.checkCondition(ctx, company, user, condition)
+		match, err := s.checkCondition(ctx, scope, condition)
 		if err != nil {
 			return false, err
 		}
@@ -121,25 +129,48 @@ func (s *RuleCheckService) checkCompanyCondition(ctx context.Context, company *C
 	return resourceMatch, nil
 }
 
-func (s *RuleCheckService) checkCreditBalanceCondition(ctx context.Context, company *Company, condition *Condition) (bool, error) {
-	if condition.ConditionType != ConditionTypeCredit || company == nil || condition.CreditID == nil {
+func (s *RuleCheckService) checkCreditBalanceCondition(ctx context.Context, scope *CheckScope, condition *Condition) (bool, error) {
+	if condition.ConditionType != ConditionTypeCredit || scope.Company == nil || condition.CreditID == nil {
 		return false, nil
 	}
 
-	var consumptionCost = float64(1)
+	consumptionRate := float64(1)
 	if condition.ConsumptionRate != nil {
-		consumptionCost = *condition.ConsumptionRate
+		consumptionRate = *condition.ConsumptionRate
 	}
 
 	var creditBalance float64
-	for creditID, balance := range company.CreditBalances {
+	for creditID, balance := range scope.Company.CreditBalances {
 		if creditID == *condition.CreditID {
 			creditBalance = balance
 			break
 		}
 	}
 
-	return creditBalance >= consumptionCost, nil
+	// Precedence on credit-balance conditions, most specific first. No
+	// options supplied falls through to the legacy single-unit check.
+	//   1. creditCost[credit_id]: caller-supplied per-call cost in credits;
+	//      gate on balance >= cost.
+	//   2. eventUsage[condition.EventSubtype]: simulated quantity for this
+	//      specific event; gate on balance >= quantity × consumption_rate.
+	//   3. usage: generic quantity (no event disambiguation); gate on
+	//      balance >= quantity × consumption_rate.
+	//   4. Legacy: balance >= consumption_rate (single unit).
+	if cost, ok := scope.creditCost[*condition.CreditID]; ok {
+		return creditBalance >= cost, nil
+	}
+
+	if condition.EventSubtype != nil {
+		if quantity, ok := scope.eventUsage[*condition.EventSubtype]; ok && quantity > 0 {
+			return creditBalance >= float64(quantity)*consumptionRate, nil
+		}
+	}
+
+	if scope.usage != nil && *scope.usage > 0 {
+		return creditBalance >= float64(*scope.usage)*consumptionRate, nil
+	}
+
+	return creditBalance >= consumptionRate, nil
 }
 
 func (s *RuleCheckService) checkBillingProductCondition(ctx context.Context, company *Company, condition *Condition) (bool, error) {
@@ -209,17 +240,26 @@ func (s *RuleCheckService) checkBasePlanCondition(ctx context.Context, company *
 
 func (s *RuleCheckService) checkMetricCondition(
 	ctx context.Context,
-	company *Company,
+	scope *CheckScope,
 	condition *Condition,
 ) (bool, error) {
-	if condition == nil || condition.ConditionType != ConditionTypeMetric || company == nil || condition.EventSubtype == nil {
+	if condition == nil || condition.ConditionType != ConditionTypeMetric || scope.Company == nil || condition.EventSubtype == nil {
 		return false, nil
 	}
 
 	leftVal := int64(0)
-	metric := company.Metrics.Find(*condition.EventSubtype, condition.MetricPeriod, condition.MetricPeriodMonthReset)
+	metric := scope.Company.Metrics.Find(*condition.EventSubtype, condition.MetricPeriod, condition.MetricPeriodMonthReset)
 	if metric != nil {
 		leftVal = metric.Value
+	}
+
+	// Preflight: simulate additional usage on top of the current metric value.
+	// eventUsage takes precedence over usage so a caller can target a specific
+	// subtype when several may be in flight.
+	if quantity, ok := scope.eventUsage[*condition.EventSubtype]; ok && quantity > 0 {
+		leftVal += quantity
+	} else if scope.usage != nil && *scope.usage > 0 {
+		leftVal += *scope.usage
 	}
 
 	if condition.MetricValue == nil {
@@ -228,7 +268,7 @@ func (s *RuleCheckService) checkMetricCondition(
 
 	rightVal := *condition.MetricValue
 	if condition.ComparisonTraitDefinition != nil {
-		comparisonTrait := s.findTrait(ctx, condition.ComparisonTraitDefinition, company.Traits)
+		comparisonTrait := s.findTrait(ctx, condition.ComparisonTraitDefinition, scope.Company.Traits)
 		if comparisonTrait == nil {
 			rightVal = 0
 		} else {
@@ -240,7 +280,7 @@ func (s *RuleCheckService) checkMetricCondition(
 
 }
 
-func (s *RuleCheckService) checkTraitCondition(ctx context.Context, company *Company, user *User, condition *Condition) (bool, error) {
+func (s *RuleCheckService) checkTraitCondition(ctx context.Context, scope *CheckScope, condition *Condition) (bool, error) {
 	if condition == nil || condition.ConditionType != ConditionTypeTrait || condition.TraitDefinition == nil {
 		return false, nil
 	}
@@ -248,17 +288,17 @@ func (s *RuleCheckService) checkTraitCondition(ctx context.Context, company *Com
 	traitDef := condition.TraitDefinition
 	var trait *Trait
 	var comparisonTrait *Trait
-	if traitDef.EntityType == EntityTypeCompany && company != nil {
-		trait = s.findTrait(ctx, traitDef, company.Traits)
-		comparisonTrait = s.findTrait(ctx, condition.ComparisonTraitDefinition, company.Traits)
-	} else if traitDef.EntityType == EntityTypeUser && user != nil {
-		trait = s.findTrait(ctx, traitDef, user.Traits)
-		comparisonTrait = s.findTrait(ctx, condition.ComparisonTraitDefinition, user.Traits)
+	if traitDef.EntityType == EntityTypeCompany && scope.Company != nil {
+		trait = s.findTrait(ctx, traitDef, scope.Company.Traits)
+		comparisonTrait = s.findTrait(ctx, condition.ComparisonTraitDefinition, scope.Company.Traits)
+	} else if traitDef.EntityType == EntityTypeUser && scope.User != nil {
+		trait = s.findTrait(ctx, traitDef, scope.User.Traits)
+		comparisonTrait = s.findTrait(ctx, condition.ComparisonTraitDefinition, scope.User.Traits)
 	} else {
 		return false, nil
 	}
 
-	return s.compareTraits(ctx, condition, trait, comparisonTrait), nil
+	return s.compareTraits(ctx, scope, condition, trait, comparisonTrait), nil
 }
 
 func (s *RuleCheckService) checkUserCondition(ctx context.Context, user *User, condition *Condition) (bool, error) {
@@ -274,7 +314,7 @@ func (s *RuleCheckService) checkUserCondition(ctx context.Context, user *User, c
 	return resourceMatch, nil
 }
 
-func (s *RuleCheckService) compareTraits(ctx context.Context, condition *Condition, trait *Trait, comparisonTrait *Trait) bool {
+func (s *RuleCheckService) compareTraits(ctx context.Context, scope *CheckScope, condition *Condition, trait *Trait, comparisonTrait *Trait) bool {
 	var leftVal string
 	rightVal := condition.TraitValue
 	if trait != nil {
@@ -287,6 +327,15 @@ func (s *RuleCheckService) compareTraits(ctx context.Context, condition *Conditi
 	comparableType := typeconvert.ComparableTypeString
 	if trait != nil && trait.TraitDefinition != nil {
 		comparableType = trait.TraitDefinition.ComparableType
+	}
+
+	// Preflight: when the trait is int-comparable and the caller supplied
+	// generic usage, simulate adding it to the trait value. eventUsage is
+	// intentionally not applied here because traits aren't keyed by
+	// event_subtype.
+	if comparableType == typeconvert.ComparableTypeInt && scope.usage != nil && *scope.usage > 0 {
+		current := typeconvert.StringToInt64(leftVal)
+		leftVal = fmt.Sprintf("%d", current+*scope.usage)
 	}
 
 	return typeconvert.Compare(leftVal, rightVal, comparableType, condition.Operator)


### PR DESCRIPTION
Inspired by #12, which I think we were pretty happy with at the time, but adds a third option (`WithCreditCost`) in addition to `WithUsage` / `WithEventUsage` already proposed there.

- **`WithCreditCost(creditID, cost)`**: May be common in situations where this is used in parallel with a usage-based billing provider; the caller has already computed the per-call cost in credits and wants the engine to gate directly on `balance >= cost`, with no quantity or `consumption_rate` math.
- **`WithUsage(quantity)`**: generic quantity. For metric and trait-int conditions, the quantity is added to the current value. For credit-balance conditions, the credit cost compared against the balance is `quantity × consumption_rate`.
- **`WithEventUsage(event_subtype, quantity)`**: Applied to metric conditions whose event_subtype matches (added to the current metric value) and to credit-balance conditions whose event_subtype matches (compared as `quantity × consumption_rate` against the balance). Preferred over `WithUsage` in cases where the event_subtype is known.


It is possible for callers to provide multiple options; the engine picks the most specific one for each condition. E.G.:
- Credit-balance conditions: `WithCreditCost` > `WithEventUsage` > `WithUsage`
- Metric conditions: `WithEventUsage` > `WithUsage`
- Trait-int conditions: only `WithUsage` applies

These options are, of course, optional; the pre-existing behavior is used if none are provided.