### PR TITLE
serialize nil slice fields as [] instead of null on wire types

### DIFF
--- a/json_slice.go
+++ b/json_slice.go
@@ -1,0 +1,49 @@
+package rulesengine
+
+import (
+	"encoding/json"
+)
+
+// JSONSlice is a wrapper type that ensures slices are serialized as empty
+// arrays instead of null when they are nil. Strictly-typed JSON consumers
+// (e.g. Fern-generated SDKs) reject `null` for list-typed fields, so wire
+// types declared with []T cannot use Go's default nil-slice marshaling
+// without back-compat workarounds in every SDK.
+type JSONSlice[T any] []T
+
+func NewJSONSlice[T any](slice []T) JSONSlice[T] {
+	if slice == nil {
+		return JSONSlice[T]{}
+	}
+	return JSONSlice[T](slice)
+}
+
+func (s JSONSlice[T]) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		return json.Marshal([]T{})
+	}
+	return json.Marshal([]T(s))
+}
+
+func (s *JSONSlice[T]) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*s = JSONSlice[T]{}
+		return nil
+	}
+
+	var slice []T
+	if err := json.Unmarshal(data, &slice); err != nil {
+		return err
+	}
+
+	*s = JSONSlice[T](slice)
+	return nil
+}
+
+func (s JSONSlice[T]) Slice() []T {
+	if s == nil {
+		return []T{}
+	}
+
+	return []T(s)
+}

--- a/json_slice_test.go
+++ b/json_slice_test.go
@@ -1,0 +1,161 @@
+package rulesengine
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONSlice_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{
+			name: "nil slice serializes as empty array",
+			input: struct {
+				Items JSONSlice[string] `json:"items"`
+			}{Items: nil},
+			expected: `{"items":[]}`,
+		},
+		{
+			name: "empty slice serializes as empty array",
+			input: struct {
+				Items JSONSlice[string] `json:"items"`
+			}{Items: JSONSlice[string]{}},
+			expected: `{"items":[]}`,
+		},
+		{
+			name: "populated slice serializes normally",
+			input: struct {
+				Items JSONSlice[string] `json:"items"`
+			}{Items: JSONSlice[string]{"a", "b", "c"}},
+			expected: `{"items":["a","b","c"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestJSONSlice_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected JSONSlice[string]
+	}{
+		{
+			name:     "null unmarshals to empty slice",
+			input:    `{"items":null}`,
+			expected: JSONSlice[string]{},
+		},
+		{
+			name:     "empty array unmarshals to empty slice",
+			input:    `{"items":[]}`,
+			expected: JSONSlice[string]{},
+		},
+		{
+			name:     "populated array unmarshals correctly",
+			input:    `{"items":["a","b","c"]}`,
+			expected: JSONSlice[string]{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result struct {
+				Items JSONSlice[string] `json:"items"`
+			}
+			err := json.Unmarshal([]byte(tt.input), &result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result.Items)
+		})
+	}
+}
+
+func TestJSONSlice_PointerElements(t *testing.T) {
+	type Item struct {
+		ID string `json:"id"`
+	}
+
+	data, err := json.Marshal(struct {
+		Items JSONSlice[*Item] `json:"items"`
+	}{Items: nil})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"items":[]}`, string(data))
+}
+
+// Verifies that an unnamed []T literal is assignable to a JSONSlice[T] field,
+// so existing call sites that construct rulesengine types via composite
+// literals (Flag{Rules: []*Rule{...}}) continue to compile.
+func TestJSONSlice_AssignableFromBareSliceLiteral(t *testing.T) {
+	type wrapper struct {
+		Items JSONSlice[string] `json:"items"`
+	}
+
+	w := wrapper{Items: []string{"a", "b"}}
+	assert.Len(t, w.Items, 2)
+}
+
+// Verifies that rulesengine wire types emit `[]` instead of `null` for nil
+// slice fields after the migration to JSONSlice. This is the contract the
+// upstream Fern-generated SDKs depend on.
+func TestRulesengineWireTypes_NilSlicesMarshalAsEmpty(t *testing.T) {
+	t.Run("Flag with nil Rules", func(t *testing.T) {
+		data, err := json.Marshal(&Flag{Key: "k"})
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"rules":[]`)
+		assert.NotContains(t, string(data), `"rules":null`)
+	})
+
+	t.Run("Rule with nil Conditions and ConditionGroups", func(t *testing.T) {
+		data, err := json.Marshal(&Rule{ID: "r"})
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"conditions":[]`)
+		assert.Contains(t, string(data), `"condition_groups":[]`)
+	})
+
+	t.Run("Condition with nil ResourceIDs", func(t *testing.T) {
+		data, err := json.Marshal(&Condition{ID: "c"})
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"resource_ids":[]`)
+	})
+
+	t.Run("ConditionGroup with nil Conditions", func(t *testing.T) {
+		data, err := json.Marshal(&ConditionGroup{})
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"conditions":[]`)
+	})
+
+	t.Run("Company with nil slice fields", func(t *testing.T) {
+		data, err := json.Marshal(&Company{ID: "co"})
+		require.NoError(t, err)
+		s := string(data)
+		for _, key := range []string{
+			`"billing_product_ids":[]`,
+			`"plan_ids":[]`,
+			`"plan_version_ids":[]`,
+			`"rules":[]`,
+			`"traits":[]`,
+			`"metrics":[]`,
+		} {
+			assert.Contains(t, s, key)
+		}
+	})
+
+	t.Run("User with nil slice fields", func(t *testing.T) {
+		data, err := json.Marshal(&User{ID: "u"})
+		require.NoError(t, err)
+		s := string(data)
+		assert.Contains(t, s, `"traits":[]`)
+		assert.Contains(t, s, `"rules":[]`)
+	})
+}

--- a/models.go
+++ b/models.go
@@ -1,6 +1,7 @@
 package rulesengine
 
 import (
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -14,25 +15,25 @@ type TraitDefinition struct {
 }
 
 type Flag struct {
-	ID            string  `json:"id"`
-	AccountID     string  `json:"account_id"`
-	EnvironmentID string  `json:"environment_id"`
-	Key           string  `json:"key"`
-	Rules         []*Rule `json:"rules"`
-	DefaultValue  bool    `json:"default_value"`
+	ID            string           `json:"id"`
+	AccountID     string           `json:"account_id"`
+	EnvironmentID string           `json:"environment_id"`
+	Key           string           `json:"key"`
+	Rules         JSONSlice[*Rule] `json:"rules"`
+	DefaultValue  bool             `json:"default_value"`
 }
 
 type Rule struct {
-	ID              string            `json:"id"`
-	FlagID          *string           `json:"flag_id"`
-	AccountID       string            `json:"account_id"`
-	EnvironmentID   string            `json:"environment_id"`
-	RuleType        RuleType          `json:"rule_type" binding:"oneof=default global_override company_override company_override_usage_exceeded plan_entitlement plan_entitlement_usage_exceeded standard"`
-	Name            string            `json:"name"`
-	Priority        int64             `json:"priority"`
-	Conditions      []*Condition      `json:"conditions"`
-	ConditionGroups []*ConditionGroup `json:"condition_groups"`
-	Value           bool              `json:"value"`
+	ID              string                     `json:"id"`
+	FlagID          *string                    `json:"flag_id"`
+	AccountID       string                     `json:"account_id"`
+	EnvironmentID   string                     `json:"environment_id"`
+	RuleType        RuleType                   `json:"rule_type" binding:"oneof=default global_override company_override company_override_usage_exceeded plan_entitlement plan_entitlement_usage_exceeded standard"`
+	Name            string                     `json:"name"`
+	Priority        int64                      `json:"priority"`
+	Conditions      JSONSlice[*Condition]      `json:"conditions"`
+	ConditionGroups JSONSlice[*ConditionGroup] `json:"condition_groups"`
+	Value           bool                       `json:"value"`
 }
 
 type Condition struct {
@@ -43,7 +44,7 @@ type Condition struct {
 	Operator      typeconvert.ComparableOperator `json:"operator" binding:"oneof=eq ne gt lt gte lte is_empty not_empty"`
 
 	// Fields relevant when ConditionType is one of Company, User, Plan, Plan Version, Base Plan, Billing Product, or Billing Credit
-	ResourceIDs []string `json:"resource_ids"`
+	ResourceIDs JSONSlice[string] `json:"resource_ids"`
 
 	// Fields relevant when ConditionType = Event
 	EventSubtype           *string                 `json:"event_subtype"`
@@ -64,7 +65,7 @@ type Condition struct {
 }
 
 type ConditionGroup struct {
-	Conditions []*Condition `json:"conditions"`
+	Conditions JSONSlice[*Condition] `json:"conditions"`
 }
 
 // Evaluation objects
@@ -82,6 +83,16 @@ type CompanyMetric struct {
 }
 
 type CompanyMetricCollection []*CompanyMetric
+
+// MarshalJSON ensures a nil collection serializes as `[]` rather than
+// `null`, matching the JSONSlice contract that the rest of the wire types
+// in this package follow.
+func (c CompanyMetricCollection) MarshalJSON() ([]byte, error) {
+	if c == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]*CompanyMetric(c))
+}
 
 func (c CompanyMetricCollection) Find(
 	eventSubtype string,
@@ -145,17 +156,17 @@ type Company struct {
 	AccountID     string `json:"account_id"`
 	EnvironmentID string `json:"environment_id"`
 
-	BasePlanID        *string                 `json:"base_plan_id"`
-	BillingProductIDs []string                `json:"billing_product_ids"`
-	CreditBalances    map[string]float64      `json:"credit_balances"`
-	Entitlements      []*FeatureEntitlement   `json:"entitlements,omitempty"`
-	Keys              map[string]string       `json:"keys"`
-	Metrics           CompanyMetricCollection `json:"metrics"`
-	PlanIDs           []string                `json:"plan_ids"`
-	PlanVersionIDs    []string                `json:"plan_version_ids"`
-	Rules             []*Rule                 `json:"rules"`
-	Subscription      *Subscription           `json:"subscription"`
-	Traits            []*Trait                `json:"traits"`
+	BasePlanID        *string                        `json:"base_plan_id"`
+	BillingProductIDs JSONSlice[string]              `json:"billing_product_ids"`
+	CreditBalances    map[string]float64             `json:"credit_balances"`
+	Entitlements      JSONSlice[*FeatureEntitlement] `json:"entitlements,omitempty"`
+	Keys              map[string]string              `json:"keys"`
+	Metrics           CompanyMetricCollection        `json:"metrics"`
+	PlanIDs           JSONSlice[string]              `json:"plan_ids"`
+	PlanVersionIDs    JSONSlice[string]              `json:"plan_version_ids"`
+	Rules             JSONSlice[*Rule]               `json:"rules"`
+	Subscription      *Subscription                  `json:"subscription"`
+	Traits            JSONSlice[*Trait]              `json:"traits"`
 
 	mu sync.Mutex `json:"-"` // mutex for thread safety
 }
@@ -215,6 +226,6 @@ type User struct {
 	EnvironmentID string `json:"environment_id"`
 
 	Keys   map[string]string `json:"keys"`
-	Traits []*Trait          `json:"traits"`
-	Rules  []*Rule           `json:"rules"`
+	Traits JSONSlice[*Trait] `json:"traits"`
+	Rules  JSONSlice[*Rule]  `json:"rules"`
 }


### PR DESCRIPTION
I ran into a serialization issue while working with schematic-node datastream types that would be solved by having JSONSlice here.

The longer term solution is, I think, what we discussed (update schematic-go to use wasm + move these types into schematic-api), but for now this is a good quick fix.