### PR TITLE
collapse preflight eventUsage to a single subtype pair

### DIFF
--- a/flagcheck_test.go
+++ b/flagcheck_test.go
@@ -1045,6 +1045,27 @@ func TestCheckFlag(t *testing.T) {
 			assert.Equal(t, &rule.ID, result.RuleID)
 		})
 
+		t.Run("Repeated WithEventUsage replaces the previous pair", func(t *testing.T) {
+			// Last write wins (matching WithUsage): the surviving pair is
+			// ("api-calls", 100) → 100 × 0.05 = 5 needed, balance 10 → true.
+			// If the earlier ("api-calls", 1M) entry survived, the check
+			// would fail.
+			company := createTestCompany()
+			creditID := "credit-abc"
+			eventSubtype := "api-calls"
+			company.CreditBalances = map[string]float64{creditID: 10.0}
+
+			flag, rule := creditFlag(creditID, 0.05, &eventSubtype)
+
+			result, err := rulesengine.CheckFlag(ctx, company, nil, flag,
+				rulesengine.WithEventUsage(eventSubtype, 1_000_000),
+				rulesengine.WithEventUsage(eventSubtype, 100),
+			)
+
+			assert.NoError(t, err)
+			assert.Equal(t, &rule.ID, result.RuleID)
+		})
+
 		t.Run("WithEventUsage preferred over WithUsage on credit balance", func(t *testing.T) {
 			// event_usage matches subtype → 5 × 1 = 5 needed, balance 10 → true.
 			// usage 1M × 1 = 1M would fail. event_usage must win.

--- a/options.go
+++ b/options.go
@@ -47,10 +47,8 @@ type checkFlagOptions struct {
 	// metric conditions whose event_subtype matches (quantity is added to
 	// the current metric value) and to credit-balance conditions whose
 	// event_subtype matches (compared as `quantity × consumption_rate`
-	// against the balance). Deliberately singular: one check preflights one
-	// action, and per-condition gating doesn't aggregate costs across
-	// subtypes, so multiple pairs against the same credit balance could
-	// each pass while the combined cost overdraws.
+	// against the balance). Deliberately singular: one check preflights
+	// one action.
 	eventUsage *eventUsage
 }
 

--- a/options.go
+++ b/options.go
@@ -24,10 +24,10 @@ type CheckFlagOption func(*checkFlagOptions)
 //
 // Callers can provide multiple options; the engine picks the most specific
 // one for each condition it evaluates. For credit-balance conditions:
-// CreditCost (keyed by credit_id) wins over EventUsage (keyed by
-// event_subtype) wins over Usage (generic). For metric conditions:
-// EventUsage wins over Usage when the subtype matches. Trait conditions
-// only ever use Usage.
+// CreditCost (keyed by credit_id) wins over EventUsage (when its subtype
+// matches) wins over Usage (generic). For metric conditions: EventUsage
+// wins over Usage when the subtype matches. Trait conditions only ever
+// use Usage.
 type checkFlagOptions struct {
 	// creditCost is keyed by billing_credit_id → a per-call cost in credits
 	// the caller has already computed. When a credit-balance condition
@@ -43,13 +43,21 @@ type checkFlagOptions struct {
 	// disambiguate across event subtypes.
 	usage *int64
 
-	// eventUsage is keyed by event_subtype → simulated quantity. Lets the
-	// caller target a specific subtype when several may be in flight.
-	// Applied to metric conditions whose event_subtype matches (quantity is
-	// added to the current metric value) and to credit-balance conditions
-	// whose event_subtype matches (compared as `quantity × consumption_rate`
-	// against the balance).
-	eventUsage map[string]int64
+	// eventUsage is a single (event_subtype, quantity) pair. Applied to
+	// metric conditions whose event_subtype matches (quantity is added to
+	// the current metric value) and to credit-balance conditions whose
+	// event_subtype matches (compared as `quantity × consumption_rate`
+	// against the balance). Deliberately singular: one check preflights one
+	// action, and per-condition gating doesn't aggregate costs across
+	// subtypes, so multiple pairs against the same credit balance could
+	// each pass while the combined cost overdraws.
+	eventUsage *eventUsage
+}
+
+// eventUsage pairs an event_subtype with a simulated quantity for preflight.
+type eventUsage struct {
+	eventSubtype string
+	quantity     int64
 }
 
 // newCheckFlagOptions returns a zero-valued checkFlagOptions with its maps
@@ -57,7 +65,6 @@ type checkFlagOptions struct {
 func newCheckFlagOptions() *checkFlagOptions {
 	return &checkFlagOptions{
 		creditCost: make(map[string]float64),
-		eventUsage: make(map[string]int64),
 	}
 }
 
@@ -69,10 +76,8 @@ func (o *checkFlagOptions) validate() error {
 	if o.usage != nil && *o.usage < 0 {
 		return ErrorNegativePreflightUsage
 	}
-	for _, q := range o.eventUsage {
-		if q < 0 {
-			return ErrorNegativePreflightUsage
-		}
+	if o.eventUsage != nil && o.eventUsage.quantity < 0 {
+		return ErrorNegativePreflightUsage
 	}
 	for _, c := range o.creditCost {
 		if c < 0 {
@@ -119,9 +124,11 @@ func WithUsage(quantity int64) CheckFlagOption {
 // event_subtype matches (compared as `quantity × consumption_rate` against
 // the balance). Preferred over WithUsage on those conditions when the
 // caller knows the specific subtype. Zero is a no-op; negative quantities
-// are rejected by CheckFlag with ErrorNegativePreflightUsage.
+// are rejected by CheckFlag with ErrorNegativePreflightUsage. Calling this
+// more than once replaces the previous pair (last write wins, matching
+// WithUsage).
 func WithEventUsage(eventSubtype string, quantity int64) CheckFlagOption {
 	return func(o *checkFlagOptions) {
-		o.eventUsage[eventSubtype] = quantity
+		o.eventUsage = &eventUsage{eventSubtype: eventSubtype, quantity: quantity}
 	}
 }

--- a/rulecheck.go
+++ b/rulecheck.go
@@ -19,7 +19,7 @@ type CheckScope struct {
 	// behavior on every condition check.
 	creditCost map[string]float64
 	usage      *int64
-	eventUsage map[string]int64
+	eventUsage *eventUsage
 }
 
 type CheckResult struct {
@@ -151,8 +151,9 @@ func (s *RuleCheckService) checkCreditBalanceCondition(ctx context.Context, scop
 	// options supplied falls through to the legacy single-unit check.
 	//   1. creditCost[credit_id]: caller-supplied per-call cost in credits;
 	//      gate on balance >= cost.
-	//   2. eventUsage[condition.EventSubtype]: simulated quantity for this
-	//      specific event; gate on balance >= quantity × consumption_rate.
+	//   2. eventUsage, when its event_subtype matches the condition's:
+	//      simulated quantity for this specific event; gate on
+	//      balance >= quantity × consumption_rate.
 	//   3. usage: generic quantity (no event disambiguation); gate on
 	//      balance >= quantity × consumption_rate.
 	//   4. Legacy: balance >= consumption_rate (single unit).
@@ -160,10 +161,9 @@ func (s *RuleCheckService) checkCreditBalanceCondition(ctx context.Context, scop
 		return creditBalance >= cost, nil
 	}
 
-	if condition.EventSubtype != nil {
-		if quantity, ok := scope.eventUsage[*condition.EventSubtype]; ok && quantity > 0 {
-			return creditBalance >= float64(quantity)*consumptionRate, nil
-		}
+	if eu := scope.eventUsage; eu != nil && condition.EventSubtype != nil &&
+		eu.eventSubtype == *condition.EventSubtype && eu.quantity > 0 {
+		return creditBalance >= float64(eu.quantity)*consumptionRate, nil
 	}
 
 	if scope.usage != nil && *scope.usage > 0 {
@@ -254,10 +254,10 @@ func (s *RuleCheckService) checkMetricCondition(
 	}
 
 	// Preflight: simulate additional usage on top of the current metric value.
-	// eventUsage takes precedence over usage so a caller can target a specific
-	// subtype when several may be in flight.
-	if quantity, ok := scope.eventUsage[*condition.EventSubtype]; ok && quantity > 0 {
-		leftVal += quantity
+	// eventUsage takes precedence over usage when its subtype matches the
+	// condition's.
+	if eu := scope.eventUsage; eu != nil && eu.eventSubtype == *condition.EventSubtype && eu.quantity > 0 {
+		leftVal += eu.quantity
 	} else if scope.usage != nil && *scope.usage > 0 {
 		leftVal += *scope.usage
 	}


### PR DESCRIPTION
Changes `checkFlagOptions.eventUsage` from a subtype-keyed map to a single `(eventSubtype, quantity)` pair, before anything consumes the new preflight options (added in #22).

One check preflights one action, and per-condition gating doesn't aggregate costs across subtypes — multiple pairs against the same credit balance could each pass while the combined cost overdraws. Repeated `WithEventUsage` calls now last-write-win, matching `WithUsage`.

Companion changes: Rust engine (schematic-api#5797) and the schematic-node envelope on the credit-lease branch.