### PR TITLE
add CreditReserved and CreditSettled to FeatureEntitlement

### DIFF
--- a/models.go
+++ b/models.go
@@ -148,9 +148,9 @@ type FeatureEntitlement struct {
 	CreditID        *string                 `json:"credit_id" desc:"If the company has a credit-based entitlement for this feature, the ID of the credit"`
 	CreditTotal     *float64                `json:"credit_total" desc:"If the company has a credit-based entitlement for this feature, the total credit amount"`
 	CreditUsed      *float64                `json:"credit_used" desc:"If the company has a credit-based entitlement for this feature, the amount of credit used"`
-	CreditRemaining *float64                `json:"credit_remaining" desc:"If the company has a credit-based entitlement for this feature, the remaining credit amount"`
-	CreditReserved  *float64                `json:"credit_reserved,omitempty" desc:"If the company has a credit-based entitlement for this feature, the amount currently held by an open lease (granted minus tracked)"`
-	CreditSettled   *float64                `json:"credit_settled,omitempty" desc:"If the company has a credit-based entitlement for this feature, the spendable balance including open lease holds (remaining plus reserved)"`
+	CreditRemaining *float64                `json:"credit_remaining" desc:"If the company has a credit-based entitlement for this feature, the credit available to fund new consumption or a new lease hold — open lease holds are excluded. Clients that hold a lease should gate on this plus their own unspent hold; clients with no lease awareness should use credit_settled instead"`
+	CreditReserved  *float64                `json:"credit_reserved,omitempty" desc:"If the company has a credit-based entitlement for this feature, the unspent amount held by an open credit lease. Returns to credit_remaining when the lease is released"`
+	CreditSettled   *float64                `json:"credit_settled,omitempty" desc:"If the company has a credit-based entitlement for this feature, the balance net of actual consumption, unaffected by open lease holds (credit_remaining plus credit_reserved). The number to display to end users"`
 }
 
 type Company struct {

--- a/models.go
+++ b/models.go
@@ -149,6 +149,8 @@ type FeatureEntitlement struct {
 	CreditTotal     *float64                `json:"credit_total" desc:"If the company has a credit-based entitlement for this feature, the total credit amount"`
 	CreditUsed      *float64                `json:"credit_used" desc:"If the company has a credit-based entitlement for this feature, the amount of credit used"`
 	CreditRemaining *float64                `json:"credit_remaining" desc:"If the company has a credit-based entitlement for this feature, the remaining credit amount"`
+	CreditReserved  *float64                `json:"credit_reserved,omitempty" desc:"If the company has a credit-based entitlement for this feature, the amount currently held by an open lease (granted minus tracked)"`
+	CreditSettled   *float64                `json:"credit_settled,omitempty" desc:"If the company has a credit-based entitlement for this feature, the spendable balance including open lease holds (remaining plus reserved)"`
 }
 
 type Company struct {


### PR DESCRIPTION
Additive fields for SCH-6526 (lease-aware balances over DataStream).

`credit_reserved` = amount held by an open credit lease (granted − tracked); `credit_settled` = spendable balance including open holds (remaining + reserved). Emitted by the API so non-lease-holding clients (schematic-react, dashboard) can show a live balance during an open lease instead of the frozen post-acquire `credit_remaining`. Both `omitempty` — absent for non-credit entitlements and for payloads from older API versions.